### PR TITLE
Fix problem with pattern match to record.

### DIFF
--- a/code/ch11/ex2-records/record_drop.ex
+++ b/code/ch11/ex2-records/record_drop.ex
@@ -2,7 +2,7 @@ defmodule RecordDrop do
   require Planemo
   require Tower
 
-  def fall_velocity(t = Tower) do
+  def fall_velocity(t = Tower.tower()) do
     fall_velocity(Tower.tower(t, :planemo), Tower.tower(t, :height))
   end
   


### PR DESCRIPTION
This is the correct way to ensure that the item passed to a function is of the desired record type. I will make a change to the book text to match this.
