### PR TITLE
Fix warning message

### DIFF
--- a/2nd-edition/ch07/ex7-inspect/lib/tower.ex
+++ b/2nd-edition/ch07/ex7-inspect/lib/tower.ex
@@ -12,8 +12,9 @@ defimpl Inspect, for: Tower do
   import Inspect.Algebra
   def inspect(item, _options) do
     metres = concat(to_string(item.height), "m:")
-    msg = concat([metres, break, item.name, ",", break,
-      item.location, ",", break,
+    msg = concat([metres, break(), item.name, ",", break(),
+      item.location, ",", break(),
       to_string(item.planemo)])
+	  msg  
   end
 end


### PR DESCRIPTION
1. Add parentheses to "break" to fix ambiguities.
2. Add "msg" to the end of the "inspect" function (fix warning of the compiler)