### PR TITLE
Fix warning messages

### DIFF
--- a/2nd-edition/ch12/ex7-ets-calculator/lib/drop.ex
+++ b/2nd-edition/ch12/ex7-ets-calculator/lib/drop.ex
@@ -1,15 +1,15 @@
 defmodule Drop do
   require Planemo
   def drop do
-    setup
-    handle_drops
+    setup()
+    handle_drops()
   end
 
-  def handle_drops do
+  def handle_drops() do
     receive do
       {from, planemo, distance} ->
         send(from, {planemo, distance, fall_velocity(planemo, distance)})
-        handle_drops
+        handle_drops()
     end
   end
 
@@ -18,7 +18,7 @@ defmodule Drop do
     :math.sqrt(2 * Planemo.planemo(p, :gravity) * distance)
   end
 
-  def setup do
+  def setup() do
     :ets.new(:planemos, [:named_table,
       {:keypos, Planemo.planemo(:name) + 1}])
     info = [


### PR DESCRIPTION
Add parenthesis to the function definitions to remove ambiguities.