### PR TITLE
Fix heredoc, String.strip warnng messages

### DIFF
--- a/2nd-edition/ch05/ex2-ask/lib/ask.ex
+++ b/2nd-edition/ch05/ex2-ask/lib/ask.ex
@@ -7,8 +7,9 @@ defmodule Ask do
   end
 
   defp get_planemo() do
-    IO.puts("""
-    Which planemo are you on?
+    IO.puts(
+     """
+     Which planemo are you on?
      1. Earth
      2. Earth's Moon
      3. Mars
@@ -21,7 +22,7 @@ defmodule Ask do
 
 defp get_distance() do
    input = IO.gets("How far? (meters) > ")
-   value = String.strip(input)
+   value = String.trim(input)
    String.to_integer(value)
 end
 


### PR DESCRIPTION
Implement correct heredoc indentation, replace deprecated function String.strip to String.trim

console information output (FYI):
warning: outdented heredoc line. The contents inside the heredoc should be inden
ted at the same level as the closing """. The following is forbidden:

    def text do
      """
    contents
      """
    end

Instead make sure the contents are indented as much as the heredoc closing:

    def text do
      """
      contents
      """
    end

The current heredoc line is indented too little
  lib/ask.ex:11

warning: String.strip/1 is deprecated. Use String.trim/1 instead
  lib/ask.ex:24