### PR TITLE
Fix waring message heredoc, String.strip

### DIFF
--- a/2nd-edition/ch05/ex3-ask/lib/ask.ex
+++ b/2nd-edition/ch05/ex3-ask/lib/ask.ex
@@ -7,7 +7,8 @@ defmodule Ask do
   end
 
   defp get_planemo() do
-    IO.puts("""
+    IO.puts(
+    """
     Which planemo are you on?
      1. Earth
      2. Earth's Moon
@@ -21,7 +22,7 @@ defmodule Ask do
 
 defp get_distance() do
    IO.gets("How far? (meters) > ")
-   |> String.strip()
+   |> String.trim()
    |> String.to_integer()
 end
 


### PR DESCRIPTION
Fix waring message heredoc, String.strip.

console output (FYI):

warning: outdented heredoc line. The contents inside the heredoc should be inden
ted at the same level as the closing """. The following is forbidden:

    def text do
      """
    contents
      """
    end

Instead make sure the contents are indented as much as the heredoc closing:

    def text do
      """
      contents
      """
    end

The current heredoc line is indented too little
  lib/ask.ex:11

warning: String.strip/1 is deprecated. Use String.trim/1 instead
  lib/ask.ex:24